### PR TITLE
Fix Django Github Action.

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -2,10 +2,10 @@ name: Django CI
 
 on:
   pull_request:
-    branches:
-      - main
-    # paths:
-    #   - 'be/osoc/**/*.py'
+    # branches:
+    #   - main
+    paths:
+      - 'be/osoc/**/*.py'
 
 jobs:
   build:


### PR DESCRIPTION
Changing `psycopg2-binary` to `psycopg2` in `requirements.txt` makes the action fail. It seems that excluding `psycopg2` and installing `psycopg2-binary` is the only solution (as I don't have sudo rights on the runner).