### PR TITLE
Added X-CSRFToken to (axios) instance

### DIFF
--- a/fe/src/utils/axios.ts
+++ b/fe/src/utils/axios.ts
@@ -19,6 +19,9 @@ function getCookie(name: String) {
 export const instance = axios.create({
   withCredentials: true,
   baseURL: 'https://sel2-5.ugent.be/api/',
+  headers: {
+    'X-CSRFToken': `${getCookie('csrftoken')}`
+  }
 })
 
 export const setCsrfToken = () =>


### PR DESCRIPTION
This solves the problems with POST,PUT,DELETE.
The X-CSRFToken was added to ```axios```, but not to ```instance```. This caused problems when editing data on the backend, since those calls use ```instance```.

#95 