### PR TITLE
Be/fix login

### DIFF
--- a/be/osoc/common/signals.py
+++ b/be/osoc/common/signals.py
@@ -6,5 +6,5 @@ from osoc.common.models import Coach
 
 @receiver(pre_save, sender=Coach)
 def set_new_user_inactive(sender, instance, **kwargs):
-    if instance._state.adding is True:
+    if instance._state.adding is True and not sender.is_admin:
         instance.is_active = False


### PR DESCRIPTION
When setting coaches to inactive I forgot to check if the coach was an admin or not, this is now fixed.