### PR TITLE
Dependency rollback

### DIFF
--- a/fe/package.json
+++ b/fe/package.json
@@ -15,7 +15,7 @@
     "@quasar/vite-plugin": "^1.0.9",
     "@types/node": "^17.0.31",
     "@vitejs/plugin-vue": "^2.3.1",
-    "@yeger/vue-masonry-wall": "3.0.31",
+    "@yeger/vue-masonry-wall": "3.0.26",
     "axios": "^0.26.1",
     "pinia": "^2.0.13",
     "pinia-plugin-persistedstate": "^1.5.1",


### PR DESCRIPTION
The newer versions of [masonry-wall](https://github.com/DerYeger/vue-masonry-wall/issues) currently have a TypeScript issue, which causes `npm run build` to fail. This PR temporarily rolls back the dependency to an older known-working version.