### PR TITLE
Enable secure websockets in production.

### DIFF
--- a/be/docker/Dockerfile.production
+++ b/be/docker/Dockerfile.production
@@ -21,7 +21,7 @@ WORKDIR /src
 
 RUN pip install --upgrade pip && \
     pip install -r requirements.txt && \
-    pip install gunicorn
+    pip install daphne
 
 CMD \
     chmod 755 ./docker/wait-for-it.sh && \
@@ -30,4 +30,4 @@ CMD \
     python manage.py collectstatic --noinput && \
     python scripts/create_data_fixtures.py && \
     python scripts/create_superuser_production.py && \
-    gunicorn osoc.wsgi -b 0.0.0.0:8000 --access-logfile 'accesslogs' --error-logfile 'errorlogs'
+    daphne osoc.asgi:application -b 0.0.0.0 -p 8000 > logs

--- a/be/osoc/asgi.py
+++ b/be/osoc/asgi.py
@@ -8,6 +8,7 @@ https://docs.djangoproject.com/en/4.0/howto/deployment/asgi/
 """
 
 import os
+import django
 
 from django.core.asgi import get_asgi_application
 
@@ -17,6 +18,7 @@ from channels.auth import AuthMiddlewareStack
 from .common.routing import ws_urlpatterns
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'osoc.settings')
+django.setup()
 
 application = ProtocolTypeRouter({
     'http': get_asgi_application(),


### PR DESCRIPTION
Server now uses `asgi` instead of `wsgi`. Closes #244.