### PR TITLE
fixed bug with switching between edit and new skill

### DIFF
--- a/fe/src/features/projects/components/ProjectSkills.vue
+++ b/fe/src/features/projects/components/ProjectSkills.vue
@@ -25,7 +25,7 @@
         color="teal"
         class="text-white"
         icon="add"
-        @click="showDialog = true"
+        @click="editSkill = undefined; showDialog = true"
       />
       <q-input
         v-model="filterSkills"


### PR DESCRIPTION
This fixes a bug where the last edited skill would still be shown when "add skill" is clicked