### PR TITLE
Fix for sidebar filters

### DIFF
--- a/fe/src/components/SideBar.vue
+++ b/fe/src/components/SideBar.vue
@@ -324,7 +324,6 @@ export default defineComponent({
   async mounted() {
     this.studentStore.$subscribe(() => {
       if (this.studentStore.shouldRefresh) {
-        console.log("refreshing!")
         this.studentStore.shouldRefresh = false
         const infscroll = this.$refs.infinite as any;
         infscroll.reset()
@@ -374,7 +373,6 @@ export default defineComponent({
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     loadStudents() {
-      console.log("reset!")
       const scroll = this.$refs.infinite as any;
       scroll.reset()
       scroll.resume()

--- a/fe/src/components/SideBar.vue
+++ b/fe/src/components/SideBar.vue
@@ -38,7 +38,6 @@
                   color="teal"
                   label="Search Students"
                   hide-bottom-space
-                  @update:modelValue="async () => await loadStudents()"
                 >
                   <template #append>
                     <q-icon
@@ -316,13 +315,16 @@ export default defineComponent({
     }
   },
   watch: {
-    filters() {
+    filters(newValue, oldValue) {
+      // Check equality of filters
+      if (JSON.stringify(oldValue) === JSON.stringify(newValue)) return
       this.loadStudents()
     }
   },
   async mounted() {
     this.studentStore.$subscribe(() => {
       if (this.studentStore.shouldRefresh) {
+        console.log("refreshing!")
         this.studentStore.shouldRefresh = false
         const infscroll = this.$refs.infinite as any;
         infscroll.reset()
@@ -372,6 +374,7 @@ export default defineComponent({
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     loadStudents() {
+      console.log("reset!")
       const scroll = this.$refs.infinite as any;
       scroll.reset()
       scroll.resume()


### PR DESCRIPTION
This fixes an issue where the sidebar would be refreshed each time a student was clicked.

Cause:
The sidebar contains a computed value `onConflictsPage`, which checks if the current page is the conflict page. If so, the filters object is replaced with a new filter object, to display only the students which have conflicts.

When we click on a student in the sidebar, the route changes to /students/:id, which triggers vue to compute `onConflictsPage` again. Then, this triggers vue to compute the `filters` computed property. And that will trigger the watcher on `filters`, which will reload the students, because it thinks the filters have been updated.

Solution:
check if the filters are changed in the watcher (by using `newValue` and `oldValue`). This is done using `JSON.stringify`, because the values of the objects need to be compared, which is not possible with `===`